### PR TITLE
aex: Track dtbtools from lineage

### DIFF
--- a/snippets/aex.xml
+++ b/snippets/aex.xml
@@ -148,6 +148,7 @@
   <project path="hardware/ril" name="android_hardware_ril" groups="pdk" remote="los" />
   <project path="hardware/ril-caf" name="android_hardware_ril" groups="pdk" remote="los" revision="lineage-15.1-caf" />
   <project path="system/nfc" name="android_system_nfc" groups="pdk" remote="los" />
+  <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" groups="pdk" remote="los" />
   <project path="system/update_engine" name="android_system_update_engine" groups="pdk" remote="los" />
   <project path="hardware/qcom/bt" name="android_hardware_qcom_bt" groups="qcom" remote="los" />
   <project path="hardware/qcom/bt-caf" name="android_hardware_qcom_bt" groups="qcom" remote="los" revision="lineage-15.1-caf" />


### PR DESCRIPTION
* Shifted from device/qcom/common/dtbtool to system/tools/dtbtool

Change-Id: Idd8d65c93c8634cf6edc65b642fe4596641181be
Signed-off-by: sb6596 <shubhamprince111@gmail.com>